### PR TITLE
Typo in how multiple predictors affects R^2

### DIFF
--- a/public/latex_notes/unit4/unit4.tex
+++ b/public/latex_notes/unit4/unit4.tex
@@ -284,7 +284,7 @@ The key point is that the new error term $\epsilon'$ in the reduced model is \em
 Instead, $\epsilon'$ absorbs the variation in $Y$ that is correlated with $X_2$ but unaccounted for by $X_1$.  
 Because $X_1$ and $X_2$ are generally correlated, part of the systematic variation explained by $X_2$ is treated as noise in the single-predictor model. Rather we have
 \begin{equation}
-{\rm var}(\epsilon') = {\rm var}(Y|X_1) = {\rm var}(\beta_1 X_1 + \beta_2 X_2 + \epsilon|X_1) = \beta_1^2{\rm var}(X_2|X_1) + \sigma_{\epsilon}^2 > \sigma_{\epsilon^2}
+{\rm var}(\epsilon') = {\rm var}(Y|X_1) = {\rm var}(\beta_1 X_1 + \beta_2 X_2 + \epsilon|X_1) = \beta_2^2{\rm var}(X_2|X_1) + \sigma_{\epsilon}^2 > \sigma_{\epsilon^2}
 \end{equation}
 hence
 \[


### PR DESCRIPTION
B1^2 was pulled out, but it should be B2^2